### PR TITLE
Updated activation event so linter triggers on files ending with .pro…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint"
   ],
   "activationEvents": [
-    "onLanguage:proto3"
+    "*"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   let events = vscode.commands.registerCommand(commandId, () => {
     vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-      if(document.languageId !== 'proto3') {
+      if (!document.fileName.endsWith(".proto")) {
         return;
       }
 


### PR DESCRIPTION
…to rather than when the proto language is set