### PR TITLE
Fix an issue with Multi-folder workspaces

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -46,10 +46,10 @@ export default class Linter {
     const exec = util.promisify(cp.exec);
 
     if (!vscode.workspace.workspaceFolders) {
-      return ""
+      return "";
     }
-    
-    let workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
+
+    let workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.getWorkspaceFolder(this.codeDocument.uri) || vscode.workspace.workspaceFolders[0];
     const cmd = `protolint lint -config_dir_path="${workspaceFolder.uri.fsPath}" ${currentFile}`;
 
     let lintResults: string = "";


### PR DESCRIPTION
There may be some issues with this PR:

* I do not know why it saved the full file again. I do have CRLF selected in VSCode. Maybe it is the incorrect line in `.editorconfig` that should be changed such as `indent_style = 2` -> `indent_style = tab`?
* I am not sure how to mock a `vscode.TextDocument` in order to test the method. I am happy to add tests though if you can point me in the right direction on mocking.