### PR TITLE
fix: allow whitespaces in target file path

### DIFF
--- a/example/nested with whitespace/baz with whitespace.proto
+++ b/example/nested with whitespace/baz with whitespace.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package service;
+
+message myMessage { }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -50,7 +50,7 @@ export default class Linter {
     }
 
     let workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.getWorkspaceFolder(this.codeDocument.uri) || vscode.workspace.workspaceFolders[0];
-    const cmd = `protolint lint -config_dir_path="${workspaceFolder.uri.fsPath}" ${currentFile}`;
+    const cmd = `protolint lint -config_dir_path="${workspaceFolder.uri.fsPath}" "${currentFile}"`;
 
     let lintResults: string = "";
     await exec(cmd).catch((error: any) => lintResults = error.stderr);


### PR DESCRIPTION
Previously silently failed when the path to the target file contained whitespace.
