### PR TITLE
Add setting for the path to protolint

### DIFF
--- a/example/foo.proto
+++ b/example/foo.proto
@@ -2,4 +2,14 @@ syntax = "proto3";
 
 package service;
 
-service myService { }
+message ServiceRequest {
+
+}
+
+message ServiceResponse {
+
+}
+
+service MyService {
+  rpc Do(ServiceRequest) returns (ServiceResponse) { }
+}

--- a/example/nested with whitespace/baz with whitespace.proto
+++ b/example/nested with whitespace/baz with whitespace.proto
@@ -2,4 +2,14 @@ syntax = "proto3";
 
 package service;
 
-message myMessage { }
+message ServiceRequest {
+
+}
+
+message ServiceResponse {
+
+}
+
+service MyService {
+  rpc Do(ServiceRequest) returns (ServiceResponse) { }
+}

--- a/example/nested/bar.proto
+++ b/example/nested/bar.proto
@@ -2,4 +2,14 @@ syntax = "proto3";
 
 package service;
 
-message myMessage { }
+message ServiceRequest {
+
+}
+
+message ServiceResponse {
+
+}
+
+service MyService {
+  rpc Do(ServiceRequest) returns (ServiceResponse) { }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,20 @@
       }
     ]
   },
+  "configuration": {
+    "type": "object",
+    "title": "protolint configuration",
+    "properties": {
+      "protolint.path": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "default": "$PATH",
+        "description": "Path of the protolint executable. Defaults to $PATH."
+      }
+    }
+  },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,5 @@ async function doLint(codeDocument: vscode.TextDocument, collection: vscode.Diag
     return new vscode.Diagnostic(error.range, error.proto.reason, vscode.DiagnosticSeverity.Warning);
   });
 
-  collection.clear();
   collection.set(codeDocument.uri, diagnostics);
 }


### PR DESCRIPTION
Resolves #25 -- Allows users to set `protolint.path` in the vscode settings.
Resolves #24 -- Set the `cwd` of protolint to the workspace rather than passing the workspace into the config field.