### PR TITLE
Add UI/UX for setting the binary path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-protolint",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-protolint",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^5.2.7",
@@ -20,7 +20,7 @@
         "vscode-test": "^1.3.0"
       },
       "engines": {
-        "vscode": "^1.14.0"
+        "vscode": "^1.31.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,15 @@
         "title": "Protolint: Lint protobuf file"
       }
     ],
+    "keybindings":[
+      {
+        "command": "protolint.lint",
+        "key": "alt+shift+l",
+        "mac": "alt+shift+l",
+        "linux": "alt+shift+l",
+        "when": "editorTextFocus"
+      }
+    ],
     "configuration": {
       "title": "protolint",
       "properties": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.8",
-    "@types/vscode": "^1.14.0",
+    "@types/vscode": "^1.31.0",
     "mocha": "^9.2.2",
     "rimraf": "^2.6.3",
     "tslint": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/plexsystems/vscode-protolint/issues"
   },
   "engines": {
-    "vscode": "^1.14.0"
+    "vscode": "^1.31.0"
   },
   "categories": [
     "Linters"
@@ -39,13 +39,13 @@
       }
     ],
     "configuration": {
-      "type": "object",
       "title": "protolint",
       "properties": {
         "protolint.path": {
           "type":  "string",
+          "scope": "machine",
           "default": "protolint",
-          "description": "Path of the protolint executable."
+          "markdownDescription": "Path of the protolint executable.\n\nDownload from: https://github.com/yoheimuta/protolint"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,14 @@
           "markdownDescription": "Path of the protolint executable.\n\nDownload from: https://github.com/yoheimuta/protolint"
         }
       }
+    },
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "protolint.lint",
+          "when": "editorLangId == proto3 || editorLangId == proto"
+        }
+      ]
     }
   },
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { DocumentSelector } from "vscode";
+
 export const PROTOLINT_REPO_URI = "https://github.com/yoheimuta/protolint";
 
 export const PATH_CONFIGURATION_KEY = "path";
@@ -6,4 +8,8 @@ export const PATH_CONFIGURATION_KEY = "path";
 // in the shell.
 export const FAILOVER_PATH = "protolint";
 
-export const TARGET_LANGUAGES = ["proto3", "proto"];
+// At the moment allows only files on a disk. Change `scheme` if start linting from memory.
+export const PROTOBUF_SELECTOR: DocumentSelector = [
+    { language: "proto3", scheme: "file" },
+    { language: "proto", scheme: "file" }
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const PROTOLINT_REPO_URI = "https://github.com/yoheimuta/protolint";
+
+export const PATH_CONFIGURATION_KEY = "path";
+
+// This works when the linter executable softlink is available 
+// in the shell.
+export const FAILOVER_PATH = "protolint";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,11 +4,19 @@ export const PROTOLINT_REPO_URI = "https://github.com/yoheimuta/protolint";
 
 export const PATH_CONFIGURATION_KEY = "path";
 
-// This works when the linter executable softlink is available 
-// in the shell.
+/**
+ * This works when the linter executable softlink is available 
+ * in the shell.
+ */
 export const FAILOVER_PATH = "protolint";
 
-// At the moment allows only files on a disk. Change `scheme` if start linting from memory.
+/**
+ * Document filter to select protocol buffer files.
+ * 
+ * @remarks
+ * 
+ * At the moment allows only files on disk. Change `scheme` if need linting from memory.
+ */
 export const PROTOBUF_SELECTOR: DocumentSelector = [
     { language: "proto3", scheme: "file" },
     { language: "proto", scheme: "file" }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,4 @@ export const FAILOVER_PATH = "protolint";
 export const PROTOBUF_SELECTOR: DocumentSelector = [
     { language: "proto3", scheme: "file" },
     { language: "proto", scheme: "file" }
-]
+];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,5 @@ export const PATH_CONFIGURATION_KEY = "path";
 // This works when the linter executable softlink is available 
 // in the shell.
 export const FAILOVER_PATH = "protolint";
+
+export const TARGET_LANGUAGES = ["proto3", "proto"];

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -5,9 +5,12 @@
 import * as vscode from 'vscode';
 import Linter, { LinterError } from './linter';
 import { PROTOBUF_SELECTOR } from './constants';
-import { isExecutableAvailable, pickPathConfiguration } from './helpers';
+import { pickPathConfiguration } from './helpers';
 
-export function subscribeToDocumentChanges(context: vscode.ExtensionContext, diagnosticCollection: vscode.DiagnosticCollection): void {
+export function subscribeToDocumentChanges(
+  context: vscode.ExtensionContext,
+  diagnosticCollection: vscode.DiagnosticCollection
+): void {
   if (vscode.window.activeTextEditor) {
     refreshDiagnostics(vscode.window.activeTextEditor.document, diagnosticCollection);
   }
@@ -55,13 +58,16 @@ export function subscribeToDocumentChanges(context: vscode.ExtensionContext, dia
  * @param doc protocol buffer document to analyze
  * @param diagnosticCollection diagnostic collection
  */
-export async function refreshDiagnostics(doc: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection): Promise<void> {
+export async function refreshDiagnostics(
+  doc: vscode.TextDocument,
+  diagnosticCollection: vscode.DiagnosticCollection
+): Promise<void> {
   if (vscode.languages.match(PROTOBUF_SELECTOR, doc) === 0) {
     diagnosticCollection.delete(doc.uri);
     return;
   }
 
-  if (isExecutableAvailable() === undefined) {
+  if (Linter.isExecutableAvailable() === undefined) {
     try {
       const result = await pickPathConfiguration();
       if (result === undefined) {
@@ -81,5 +87,4 @@ export async function refreshDiagnostics(doc: vscode.TextDocument, diagnosticCol
   });
 
   diagnosticCollection.set(doc.uri, diagnostics);
-
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -24,15 +24,21 @@ export function subscribeToDocumentChanges(context: vscode.ExtensionContext, dia
 
   context.subscriptions.push(
     vscode.workspace.onDidSaveTextDocument(
-      doc => {
-        refreshDiagnostics(doc, diagnosticCollection);
-      }
+      doc => refreshDiagnostics(doc, diagnosticCollection)
     )
   );
 
   context.subscriptions.push(
     vscode.workspace.onDidCloseTextDocument(
       doc => diagnosticCollection.delete(doc.uri)
+    )
+  );
+
+  // Refresh the diagnostics when the document language is changed 
+  // to protocol buffers.
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(
+      doc => refreshDiagnostics(doc, diagnosticCollection)
     )
   );
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import Linter, { LinterError } from './linter';
+import { PROTOBUF_SELECTOR } from './constants';
+import { isExecutableAvailable, pickPathConfiguration } from './helpers';
+
+export function subscribeToDocumentChanges(context: vscode.ExtensionContext, diagnosticCollection: vscode.DiagnosticCollection): void {
+  if (vscode.window.activeTextEditor) {
+    refreshDiagnostics(vscode.window.activeTextEditor.document, diagnosticCollection);
+  }
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(
+      editor => {
+        if (editor) {
+          refreshDiagnostics(editor.document, diagnosticCollection);
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument(
+      doc => {
+        refreshDiagnostics(doc, diagnosticCollection);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidCloseTextDocument(
+      doc => diagnosticCollection.delete(doc.uri)
+    )
+  );
+
+}
+
+/**
+ * Analyzes the protocol buffer document for problems.
+ * 
+ * @remarks
+ * If the document is not identified as protocol buffer, the diagnostics won't be added.
+ * It the document language is changed and it's not protocol buffer anymore, its 
+ * diagnostics will be deleted.
+ * 
+ * @param doc protocol buffer document to analyze
+ * @param diagnosticCollection diagnostic collection
+ */
+export async function refreshDiagnostics(doc: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection): Promise<void> {
+  if (vscode.languages.match(PROTOBUF_SELECTOR, doc) === 0) {
+    diagnosticCollection.delete(doc.uri);
+    return;
+  }
+
+  if (isExecutableAvailable() === undefined) {
+    try {
+      const result = await pickPathConfiguration();
+      if (result === undefined) {
+        return;
+      }
+    } catch (error) {
+      return;
+    }
+  }
+
+  const linter = new Linter(doc);
+  const errors: LinterError[] = await linter.lint();
+  const diagnostics = errors.map(error => {
+    const diagnostic = new vscode.Diagnostic(error.range, error.proto.reason, vscode.DiagnosticSeverity.Warning);
+    diagnostic.source = 'protolint';
+    return diagnostic;
+  });
+
+  diagnosticCollection.set(doc.uri, diagnostics);
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,9 @@ export function activate(context: vscode.ExtensionContext) {
     // E.g. saving the user's configuration via VS Code API also fires this event
     // with `jsonc` languageId, and we get an excessive error notification upon
     // saving the correct path.
-    if (!isTargetLanguage(document.languageId))
+    if (!isTargetLanguage(document.languageId)) {
       return;
+    }
 
     vscode.commands.executeCommand('protolint.lint');
   });
@@ -45,8 +46,9 @@ async function runLint() {
   if (isExecutableAvailable() === undefined) {
     try {
       const result = await pickPathConfiguration();
-      if (result === undefined)
+      if (result === undefined) {
         return;
+      }
     } catch (error) {
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,33 +1,17 @@
 import * as vscode from 'vscode';
 
-import Linter, { LinterError } from './linter';
-import { pickPathConfiguration, isExecutableAvailable, isTargetLanguage } from './helpers';
+import { refreshDiagnostics, subscribeToDocumentChanges } from './diagnostics';
 
+const LINT_COMMAND = "protolint.lint";
 const diagnosticCollection = vscode.languages.createDiagnosticCollection("protolint");
 
 export function activate(context: vscode.ExtensionContext) {
-  const lintCommand = vscode.commands.registerCommand('protolint.lint', runLint);
-  context.subscriptions.push(lintCommand);
+  context.subscriptions.push(diagnosticCollection);
+  
+  context.subscriptions.push(
+    vscode.commands.registerCommand(LINT_COMMAND, runLint));
 
-  vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-    // We need to filter the events by languageId.
-    // E.g. saving the user's configuration via VS Code API also fires this event
-    // with `jsonc` languageId, and we get an excessive error notification upon
-    // saving the correct path.
-    if (!isTargetLanguage(document.languageId)) {
-      return;
-    }
-
-    vscode.commands.executeCommand('protolint.lint');
-  });
-
-  // Run the linter when the user changes the file that they are currently viewing
-  // so that the lint results show up immediately.
-  vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => {
-    vscode.commands.executeCommand('protolint.lint');
-  });
-
-  vscode.commands.executeCommand('protolint.lint');
+  subscribeToDocumentChanges(context, diagnosticCollection);
 }
 
 async function runLint() {
@@ -36,33 +20,5 @@ async function runLint() {
     return;
   }
 
-  // We only want to run protolint on documents that are known to be
-  // protocol buffer files.
-  const doc = editor.document;
-  if (!isTargetLanguage(doc.languageId)) {
-    return;
-  }
-
-  if (isExecutableAvailable() === undefined) {
-    try {
-      const result = await pickPathConfiguration();
-      if (result === undefined) {
-        return;
-      }
-    } catch (error) {
-      return;
-    }
-  }
-
-  doLint(doc, diagnosticCollection);
-}
-
-async function doLint(codeDocument: vscode.TextDocument, collection: vscode.DiagnosticCollection): Promise<void> {
-  const linter = new Linter(codeDocument);
-  const errors: LinterError[] = await linter.lint();
-  const diagnostics = errors.map(error => {
-    return new vscode.Diagnostic(error.range, error.proto.reason, vscode.DiagnosticSeverity.Warning);
-  });
-
-  collection.set(codeDocument.uri, diagnostics);
+  refreshDiagnostics(editor.document, diagnosticCollection);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
   subscribeToDocumentChanges(context, diagnosticCollection);
 }
 
-async function runLint() {
+function runLint() {
   let editor = vscode.window.activeTextEditor;
   if (!editor) {
     return;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+
+import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH } from './constants';
+
+export function isExecutableValid(path: string): boolean {
+  const result = cp.spawnSync(path, ['version']);
+  if (result.status !== 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isExecutableAvailable(): string | undefined {
+  let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
+  if (!executablePath) {
+    // Failover when the key is missing in the configuration.
+    executablePath = FAILOVER_PATH;
+  }
+
+  if (isExecutableValid(executablePath)) {
+    return executablePath;
+  };
+
+  return undefined;
+}
+
+// Attempts to pick the protolint executable path via the OS UI.
+// If the path is correct, updates the extension configuration and returns
+// this path.
+// If user fails to provide the valid executable path, returns undefined.
+export async function locateExecutable(): Promise<string | undefined> {
+  try {
+    const userInput = await vscode.window.showOpenDialog({
+      canSelectFolders: false,
+      canSelectFiles: true,
+      canSelectMany: false,
+      openLabel: "Use for linting"
+    });
+
+    if (!userInput || userInput.length < 1) {
+      return undefined;
+    }
+
+    const path = userInput[0].fsPath;
+
+    if (isExecutableValid(path)) {
+      const config = vscode.workspace.getConfiguration('protolint');
+
+      // Always updates the global user settings, assuming the `path`
+      // scope is limited to 'machine' in package.json. It may become an
+      // issue if the scope changes (e.g. to 'window').
+      await config.update(PATH_CONFIGURATION_KEY, path, true);
+
+      return path;
+    } else {
+      return undefined;
+    }
+
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export async function pickPathConfiguration(): Promise<string | undefined> {
+  const path = isExecutableAvailable();
+  if (path !== undefined) {
+    return path;
+  }
+
+  const DOWNLOAD_ACTION = "Download";
+  const FIND_ACTION = "Find the file";
+
+  const selection = await vscode.window.showWarningMessage(
+    "Protolint executable was not detected. Find the unpacked executable if already downloaded.",
+    DOWNLOAD_ACTION,
+    FIND_ACTION
+  );
+
+  if (selection !== undefined) {
+    switch (selection) {
+      case FIND_ACTION:
+        try {
+          const result = await locateExecutable();
+          if (result === undefined) {
+            vscode.window.showErrorMessage("A valid linter executable wasn't found. Try fixing it in the settings.");
+          }
+          return result;
+        } catch (error) {
+          vscode.window.showErrorMessage("A valid linter executable wasn't found. Try fixing it in the settings.");
+          return undefined;
+        }
+        break;
+
+      case DOWNLOAD_ACTION:
+        vscode.env.openExternal(vscode.Uri.parse(PROTOLINT_REPO_URI));
+        break;
+    }
+  }
+
+  return undefined;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,27 +1,24 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 
-import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH } from './constants';
+import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH, TARGET_LANGUAGES } from './constants';
 
 export function isExecutableValid(path: string): boolean {
   const result = cp.spawnSync(path, ['version']);
-  if (result.status !== 0) {
+  if (result.status !== 0)
     return false;
-  }
 
   return true;
 }
 
 export function isExecutableAvailable(): string | undefined {
   let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
-  if (!executablePath) {
+  if (!executablePath)
     // Failover when the key is missing in the configuration.
     executablePath = FAILOVER_PATH;
-  }
 
-  if (isExecutableValid(executablePath)) {
+  if (isExecutableValid(executablePath))
     return executablePath;
-  };
 
   return undefined;
 }
@@ -39,9 +36,8 @@ export async function locateExecutable(): Promise<string | undefined> {
       openLabel: "Use for linting"
     });
 
-    if (!userInput || userInput.length < 1) {
+    if (!userInput || userInput.length < 1)
       return undefined;
-    }
 
     const path = userInput[0].fsPath;
 
@@ -100,4 +96,12 @@ export async function pickPathConfiguration(): Promise<string | undefined> {
   }
 
   return undefined;
+}
+
+// Returns true if the specified languageId is the target on for the extension.
+export function isTargetLanguage(languageId: string): boolean {
+  if (TARGET_LANGUAGES.some(item => item === languageId))
+    return true;
+
+  return false;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,20 +5,23 @@ import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH, TARGET_LANGU
 
 export function isExecutableValid(path: string): boolean {
   const result = cp.spawnSync(path, ['version']);
-  if (result.status !== 0)
+  if (result.status !== 0) {
     return false;
+  }
 
   return true;
 }
 
 export function isExecutableAvailable(): string | undefined {
   let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
-  if (!executablePath)
+  if (!executablePath) {
     // Failover when the key is missing in the configuration.
     executablePath = FAILOVER_PATH;
+  }
 
-  if (isExecutableValid(executablePath))
+  if (isExecutableValid(executablePath)) {
     return executablePath;
+  }
 
   return undefined;
 }
@@ -36,8 +39,9 @@ export async function locateExecutable(): Promise<string | undefined> {
       openLabel: "Use for linting"
     });
 
-    if (!userInput || userInput.length < 1)
+    if (!userInput || userInput.length < 1) {
       return undefined;
+    }
 
     const path = userInput[0].fsPath;
 
@@ -98,10 +102,11 @@ export async function pickPathConfiguration(): Promise<string | undefined> {
   return undefined;
 }
 
-// Returns true if the specified languageId is the target on for the extension.
+// Returns true if the specified languageId is the target one for the extension.
 export function isTargetLanguage(languageId: string): boolean {
-  if (TARGET_LANGUAGES.some(item => item === languageId))
+  if (TARGET_LANGUAGES.some(item => item === languageId)) {
     return true;
+  }
 
   return false;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 
-import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH, TARGET_LANGUAGES } from './constants';
+import { PROTOLINT_REPO_URI, PATH_CONFIGURATION_KEY, FAILOVER_PATH } from './constants';
 
 export function isExecutableValid(path: string): boolean {
   const result = cp.spawnSync(path, ['version']);
@@ -100,13 +100,4 @@ export async function pickPathConfiguration(): Promise<string | undefined> {
   }
 
   return undefined;
-}
-
-// Returns true if the specified languageId is the target one for the extension.
-export function isTargetLanguage(languageId: string): boolean {
-  if (TARGET_LANGUAGES.some(item => item === languageId)) {
-    return true;
-  }
-
-  return false;
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -2,8 +2,9 @@ import * as cp from 'child_process';
 import * as vscode from 'vscode';
 import * as util from 'util';
 import * as path from 'path';
+import * as net from 'net';
 
-import { PATH_CONFIGURATION_KEY } from './constants';
+import { FAILOVER_PATH, PATH_CONFIGURATION_KEY } from './constants';
 import { ProtoError, parseProtoError } from './protoError';
 
 export interface LinterError {
@@ -18,8 +19,88 @@ export default class Linter {
     this.codeDocument = document;
   }
 
+  /**
+   * A method for testing `protolint` executable via `version` command.
+   * 
+   * @param path - path/softlink to `protolint` executable.
+   * @returns `true` if the `version` command is completed, otherwise `false`.
+   */
+  public static isExecutableValid(path: string): boolean {
+    const result = cp.spawnSync(path, ['version']);
+    if (result.status !== 0) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Gets `protolint` executable path/softlink from the workspace configuration 
+   * and tests it via {@link isExecutableValid}.
+   * @returns `undefined` when the executable isn't available, otherwise 
+   * path/softlink to executable.
+   */
+  public static isExecutableAvailable(): string | undefined {
+    let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
+    if (!executablePath) {
+      // Failover when the key is missing in the configuration.
+      executablePath = FAILOVER_PATH;
+    }
+
+    if (this.isExecutableValid(executablePath)) {
+      return executablePath;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Returns a path for 
+   * {@link https://nodejs.org/docs/latest-v18.x/api/net.html#ipc-support | IPC connection} 
+   * to convey the current document text to the linter without saving the file.
+   * 
+   * @remarks
+   * 
+   * The path is platform-dependent and has the following structure: 
+   * `/{prefix}/{timestamp}/{doc_version}/{basename}`.
+   * 
+   * Value examples:
+   * - Windows: `\\\\?\\pipe\1681751977527\1\my.proto`
+   * - others: `/tmp/1681751977527/1/my.proto`
+   * 
+   * @returns an IPC connection path to get the text
+   */
+  protected generateIpcPath(): string {
+    const prefix: string = process.platform === 'win32' ? '\\\\?\\pipe' : '/tmp';
+
+    let name: string = path.basename(this.codeDocument.fileName);
+    if (this.codeDocument.isUntitled) {
+      name += '.proto';
+    }
+
+    return path.join(
+      prefix,
+      Date.now().toString(),
+      this.codeDocument.version.toString(),
+      name
+    );
+  }
+
   public async lint(): Promise<LinterError[]> {
-    const result = await this.runProtoLint();
+    const executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
+    if (!executablePath) {
+      return [];
+    }
+
+    let result = '';
+
+    this.codeDocument.uri.scheme === 'file' &&
+      !this.codeDocument.isClosed &&
+      !this.codeDocument.isDirty ?
+      result = await this.runFileLint(executablePath) :
+      // Convey the text via IPC when `codeDocument` has unsaved changes.
+      result = await this.runIpcLint(executablePath);
+
     if (!result) {
       return [];
     }
@@ -37,14 +118,21 @@ export default class Linter {
     return lintingErrors;
   }
 
-  private async runProtoLint(): Promise<string> {
+  /**
+   * Stable.
+   * Attempts to lint {@link codeDocument}, passing its text via file URI.
+   * Uses `cp.exec`.
+   * 
+   * @param executablePath - path/softlink to `protolint` executable
+   * @returns `stderr` text (if any), otherwise `""`
+   */
+  private async runFileLint(executablePath: string): Promise<string> {
     if (!vscode.workspace.workspaceFolders) {
       return "";
     }
 
     let currentFile = this.codeDocument.uri.fsPath;
     let currentDirectory = path.dirname(currentFile);
-    let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
 
     const cmd = `${executablePath} lint "${currentFile}"`;
 
@@ -80,5 +168,75 @@ export default class Linter {
     }, []);
 
     return result;
+  }
+
+  /**
+   * Experimental.
+   * Attempts to lint {@link codeDocument}, passing its text via
+   * {@link https://nodejs.org/docs/latest-v18.x/api/net.html#ipc-support | IPC connection}.
+   * 
+   * @remarks
+   * 
+   * This method is supposed for real-time linting, so it uses `cp.execFile` that has no 
+   * shell spawning overhead.
+   * 
+   * @param executablePath - path/softlink to `protolint` executable
+   * @returns `stderr` text (if any), otherwise `""`
+   */
+  private async runIpcLint(executablePath: string): Promise<string> {
+    const server = net.createServer(this.serverConnectionListener.bind(this));
+    server.on("error", this.serverErrorListener);
+    const ipcPath = this.generateIpcPath();
+    server.listen(ipcPath);
+
+    let lintResults: string = "";
+
+    const execFile = util.promisify(cp.execFile);
+    if (executablePath) {
+      await execFile(
+        executablePath,
+        ['lint', ipcPath]
+      ).catch((error: any) => lintResults = error.stderr);
+    }
+
+    server.unref();
+    server.close(this.serverCloseCallback);
+
+    return lintResults;
+  }
+
+  /**
+   * Listener for the 
+   * {@link https://nodejs.org/docs/latest-v18.x/api/net.html#ipc-support | IPC} 
+   * `"connection"` event in {@link net.Server}.
+   * 
+   * @param clientSocket - a {@link net.Socket} where the client attempts to read the text for linting.
+   */
+  private serverConnectionListener(clientSocket: net.Socket): void {
+    if (clientSocket.writable) {
+      clientSocket.end(this.codeDocument.getText());
+    }
+    return;
+  }
+
+  /**
+   * Listener for the 
+   * {@link https://nodejs.org/docs/latest-v18.x/api/net.html#ipc-support | IPC} 
+   * `"error"` event from {@link net.Server}.
+   */
+  private serverErrorListener(err: Error) {
+    console.error(`server error: ${err}`);
+    return;
+  }
+
+  /**
+   * The callback when {@link net.Server} is closed.
+   * @param err - error, if any.
+   */
+  private serverCloseCallback(err: Error | undefined): void {
+    if (err) {
+      console.error(err);
+    }
+    return;
   }
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as util from 'util';
 import * as path from 'path';
 
+import { PATH_CONFIGURATION_KEY } from './constants';
 import { ProtoError, parseProtoError } from './protoError';
 
 export interface LinterError {
@@ -43,13 +44,9 @@ export default class Linter {
 
     let currentFile = this.codeDocument.uri.fsPath;
     let currentDirectory = path.dirname(currentFile);
+    let executablePath = vscode.workspace.getConfiguration('protolint').get<string>(PATH_CONFIGURATION_KEY);
 
-    let protoLintPath = vscode.workspace.getConfiguration('protolint').get<string>('path');
-    if (!protoLintPath) {
-      protoLintPath = "protolint"
-    }
-
-    const cmd = `${protoLintPath} lint "${currentFile}"`;
+    const cmd = `${executablePath} lint "${currentFile}"`;
 
     // Execute the protolint binary and store the output from standard error.
     //

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -65,7 +65,7 @@ export default class Linter {
    * `/{prefix}/{timestamp}/{doc_version}/{basename}`.
    * 
    * Value examples:
-   * - Windows: `\\\\?\\pipe\1681751977527\1\my.proto`
+   * - Windows: `\\\\?\\pipe\\1681751977527\\1\\my.proto`
    * - others: `/tmp/1681751977527/1/my.proto`
    * 
    * @returns an IPC connection path to get the text


### PR DESCRIPTION
Hello, I'd like to propose UI/UX improvals for users that have just installed the extension, or downloaded the protolint and have no softlink to the binary in the OS.

Changelist:
- Limit the scope of `protolint.path` configuration, as it's usually just one per machine.
- Add the clickable repository link for Settings UI.
- Add the warning message when the default path isn't working. Buttons:
  - Open the repository link in the browser.
  - Find the binary via the system file picker (it requires vscode engine `^1.31.0`).
- Add the key binding `ALT+SHIFT+L` for `protolint.lint` command.
- Event subscription refactoring, make the necessary extension disposables to be cleared after the extension deactivation.
- Refactoring for the target language filter (use `DocumentSelector`).
- Add the diagnostic source `protolint`:
  - <img width="430" alt="image" src="https://user-images.githubusercontent.com/42497203/230669700-7b634de7-3588-4c98-b51d-4bbe94910af4.png">
- Fix a bug when linter warnings were not cleared after closing the file. I guess if you get this state and edit the file in another editor and then open again in vscode, you'll see old irrelevant warnings.
- Fix a bug when linter warnings are kept after changing the file language from `protocol buffer` to another language.
- Experimental fix for #32 using [IPC](https://nodejs.org/docs/latest-v18.x/api/net.html#ipc-support) + `child_process.execFile`.
  - Tested on Windows 10 only. Testing on Unix/macOS would be appreciated.
  - Works slower than linting a file (takes ~1-2 seconds). Probably because `protolint` makes 21 excessive readings from the socket and there's no cache for IPC.
  - At the moment IPC is used only when the document has unsaved changes.

If you're happy with the changes, we need to update readme.