### PR TITLE
fix resolve of protolint.path if configured relative

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+
+const DEFAULT_PROTO_LINT_PATH = 'protolint';
+
+let config: { protoLintPath?: string } = {
+  protoLintPath: undefined
+};
+
+export function reloadConfig(): boolean {
+  config.protoLintPath = resolveProtoLintPath();
+
+  // Verify that protolint can be successfully executed on the host machine by running the version command.
+  // In the event the binary cannot be executed, tell the user where to download protolint from.
+  const result = cp.spawnSync(config.protoLintPath, ['version']);
+  if (result.status !== 0) {
+    vscode.window.showErrorMessage("protolint was not detected using path `" + config.protoLintPath + "`. Download from: https://github.com/yoheimuta/protolint");
+    return false;
+  }
+
+  return true;
+}
+
+export function getConfig() {
+  return config;
+}
+
+function resolveProtoLintPath(): string {
+  let p = vscode.workspace.getConfiguration('protolint').get<string>('path');
+
+  if (!p || p === DEFAULT_PROTO_LINT_PATH) {
+    return DEFAULT_PROTO_LINT_PATH;
+  } else if (!path.isAbsolute(p) && vscode.workspace.workspaceFolders) {
+    return path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, p);
+  } else {
+    return p;
+  }
+}

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as util from 'util';
 import * as path from 'path';
 
+import { getConfig } from './config';
 import { ProtoError, parseProtoError } from './protoError';
 
 export interface LinterError {
@@ -44,11 +45,7 @@ export default class Linter {
     let currentFile = this.codeDocument.uri.fsPath;
     let currentDirectory = path.dirname(currentFile);
 
-    let protoLintPath = vscode.workspace.getConfiguration('protolint').get<string>('path');
-    if (!protoLintPath) {
-      protoLintPath = "protolint"
-    }
-
+    let { protoLintPath } = getConfig();
     const cmd = `${protoLintPath} lint "${currentFile}"`;
 
     // Execute the protolint binary and store the output from standard error.


### PR DESCRIPTION
Fixes relative path usage which was resolved to the user folder (~), (very unexpected behavior)

This fix allows 3 cases for protolint.path config:
- empty or default `protolint` (used as-is)
- absolute path (used as-is)
- relative (resolved relatively to the first workspace folder)

Added settings caching.
Added settings reload only if changed.